### PR TITLE
Gets rid of URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Team Members: Caleb Hurshman, Caleb Vredevoogd, David Sen,
 Michael Sisko, Michelle Ferdinands, and Ryan Vreeke
 
 
-[Domain Model](https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/Domain_Diagram.png) (https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/Domain_Diagram.png)
-[UI Model](https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/UI_Diagram.png) (https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/UI_Diagram.png)
+[Domain Model](https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/Domain_Diagram.png)
+[UI Model](https://github.com/calvin-cs262-fall2020-teamD/freetime-project/blob/master/UI_Diagram.png)


### PR DESCRIPTION
This is addressing a bit of feedback the Prof gave. It gets rid of the URLs in the README so that we just have the hyperlinks